### PR TITLE
Load site content from JSON

### DIFF
--- a/assets/content.json
+++ b/assets/content.json
@@ -1,0 +1,40 @@
+{
+  "header": {
+    "nav": [
+      {"text": "BIBLIOTECA", "href": "#biblioteca"},
+      {"text": "GRADUA\u00c7\u00c3O", "href": "#graduacao"},
+      {"text": "P\u00d3S", "href": "#pos"},
+      {"text": "NOT\u00cdCIAS", "href": "noticias.html"},
+      {"text": "SOBRE", "href": "#sobre"}
+    ],
+    "logo": {
+      "src": "assets/images/logo.webp",
+      "link": "https://www.usp.br",
+      "alt": "Logo USP"
+    }
+  },
+  "hero": {
+    "messages": [
+      "Bem-vindo ao Instituto de Alquimia",
+      "Premiado internacionalmente como melhor instituto da am\u00e9rica latina",
+      "P\u00f3s-Gradua\u00e7\u00e3o de Excel\u00eancia"
+    ]
+  },
+  "news": [
+    {
+      "image": "assets/images/image.webp",
+      "alt": "Laborat\u00f3rio de Alquimia",
+      "text": "Pesquisa revela mist\u00e9rios do laborat\u00f3rio de alquimia de cientista do s\u00e9culo 16"
+    },
+    {
+      "image": "assets/images/image2.webp",
+      "alt": "O Alquimista Paulo Coelho",
+      "text": "Tese de doutorado conecta alquimia cl\u00e1ssica \u00e0 obra de Paulo Coelho"
+    },
+    {
+      "image": "assets/images/image3.webp",
+      "alt": "Alkahest Royal Society",
+      "text": "Redescoberta de manuscritos sobre o alkahest na Royal Society"
+    }
+  ]
+}

--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -1,24 +1,20 @@
-// Injects the site header on pages
-const headerHTML = `
-<header>
-  <nav>
-    <a href="#biblioteca">BIBLIOTECA</a>
-    <a href="#graduacao">GRADUAÇÃO</a>
-    <a href="#pos">PÓS</a>
-    <a href="noticias.html">NOTÍCIAS</a>
-    <a href="#sobre">SOBRE</a>
-  </nav>
-</header>
-<div class="logo">
-  <a href="https://www.usp.br" target="_blank">
-    <img src="assets/images/logo.webp" alt="Logo USP">
-  </a>
-</div>`;
-
-function loadHeader() {
+// Injects the site header on pages reading data from content.json
+async function loadHeader() {
   const container = document.getElementById('header-placeholder');
-  if (container) {
-    container.innerHTML = headerHTML;
+  if (!container) return;
+  try {
+    const res = await fetch('assets/content.json');
+    const data = await res.json();
+    let html = '<header><nav>';
+    data.header.nav.forEach(item => {
+      html += `<a href="${item.href}">${item.text}</a>`;
+    });
+    html += '</nav></header>';
+    const logo = data.header.logo;
+    html += `<div class="logo"><a href="${logo.link}" target="_blank"><img src="${logo.src}" alt="${logo.alt}"></a></div>`;
+    container.innerHTML = html;
+  } catch (err) {
+    console.error('Falha ao carregar cabe\u00e7alho', err);
   }
 }
 

--- a/assets/js/news.js
+++ b/assets/js/news.js
@@ -1,0 +1,25 @@
+async function loadNews() {
+  const container = document.getElementById('news-cards');
+  if (!container) return;
+  try {
+    const res = await fetch('assets/content.json');
+    const data = await res.json();
+    container.innerHTML = '';
+    data.news.forEach(item => {
+      const card = document.createElement('div');
+      card.className = 'card';
+      const img = document.createElement('img');
+      img.src = item.image;
+      img.alt = item.alt || '';
+      const p = document.createElement('p');
+      p.textContent = item.text;
+      card.appendChild(img);
+      card.appendChild(p);
+      container.appendChild(card);
+    });
+  } catch (err) {
+    console.error('Falha ao carregar noticias', err);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', loadNews);

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,13 +1,19 @@
-window.addEventListener('load', () => {
-  const messages = [
-    'Bem-vindo ao Instituto de Alquimia',
-    'Premiado internacionalmente como melhor instituto da américa latina',
-    'Pós-Graduação de Excelência'
-  ];
-  const sep = ' • ';
+window.addEventListener('load', async () => {
   const scroller = document.getElementById('scroller');
   const container = scroller.parentElement;
   const speed = 1;    // px/frame
+  let messages = [];
+  try {
+    const res = await fetch('assets/content.json');
+    const data = await res.json();
+    messages = data.hero.messages;
+  } catch (err) {
+    console.error('Falha ao carregar mensagens', err);
+  }
+  if (!messages.length) {
+    messages = [''];
+  }
+  const sep = ' • ';
   let idx = 0;
   let pos;
 

--- a/index.html
+++ b/index.html
@@ -10,9 +10,7 @@
     <div class="hero">
       <div id="header-placeholder"></div>
     <div class="scroller-container">
-      <div class="scroller" id="scroller">
-        premiado internacionalmente como melhor instituto da américa latina
-      </div>
+      <div class="scroller" id="scroller"></div>
     </div>
   </div>
   <script src="assets/js/script.js"></script>

--- a/noticias.html
+++ b/noticias.html
@@ -45,20 +45,8 @@
 <body>
   <div id="header-placeholder"></div>
 
-  <section class="cards">
-    <div class="card">
-      <img src="assets/images/image.webp" alt="Laboratório de Alquimia">
-      <p>Pesquisa revela mistérios do laboratório de alquimia de cientista do século 16</p>
-    </div>
-    <div class="card">
-      <img src="assets/images/image2.webp" alt="O Alquimista Paulo Coelho">
-      <p>Tese de doutorado conecta alquimia clássica à obra de Paulo Coelho</p>
-    </div>
-    <div class="card">
-      <img src="assets/images/image3.webp" alt="Alkahest Royal Society">
-      <p>Redescoberta de manuscritos sobre o alkahest na Royal Society</p>
-    </div>
-  </section>
+  <section class="cards" id="news-cards"></section>
   <script src="assets/js/header.js"></script>
+  <script src="assets/js/news.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- centralize all site copy in a new `content.json`
- load header links and hero scroller text from the JSON
- generate news cards dynamically using JSON data
- keep pages minimal and fetch their text at runtime

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68504f990e0083218a6b9513e9f7f207